### PR TITLE
[SQLite] export type AnySQLiteUpdate

### DIFF
--- a/drizzle-orm/src/sqlite-core/query-builders/update.ts
+++ b/drizzle-orm/src/sqlite-core/query-builders/update.ts
@@ -134,7 +134,7 @@ export type SQLiteUpdate<
 	TReturning extends Record<string, unknown> | undefined = Record<string, unknown> | undefined,
 > = SQLiteUpdateBase<TTable, TResultType, TRunResult, TReturning, true, never>;
 
-type AnySQLiteUpdate = SQLiteUpdateBase<any, any, any, any, any, any>;
+export type AnySQLiteUpdate = SQLiteUpdateBase<any, any, any, any, any, any>;
 
 export interface SQLiteUpdateBase<
 	TTable extends SQLiteTable = SQLiteTable,


### PR DESCRIPTION
`insert`, `update`, `delete` and `select` versions of this type are already exported. This keeps consistency and makes it easier to build tooling around drizzle-orm.